### PR TITLE
add info.rkt and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+compiled/
+doc/
+*~

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Installation 
 
-On Mac OS X, if you've DrRacket installed, you may need to run:
-
+You can install it by either running the command
 ```
-/Applications/Racket\ v6.2/bin/raco setup pict3d
+raco pkg install git://github.com/oflatt/space-orbs
+```
+Or by opening the DrRacket package manager and entering
+```
+git://github.com/oflatt/space-orbs
+```
+As the package source.
+
+You can then run the game with the command
+```
+racket -l space-orbs/client/space-orbs-client.rkt
 ```

--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,10 @@
+#lang info
+
+(define collection "space-orbs")
+
+(define deps
+  '("base"
+    "pict3d"
+    "compatibility-lib"
+    "gui-lib"
+    "rackunit-lib"))


### PR DESCRIPTION
Adding the info.rkt allows people to install it with `raco pkg install
git://github.com/oflatt/space-orbs`, to have it install pict3d and the
other dependancies automatically.
