### PR TITLE
Don't let held keys act like repeated keys

### DIFF
--- a/client/key-events.rkt
+++ b/client/key-events.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(require rackunit pict3d "structures.rkt" "current-roll-and-pos.rkt" "variables.rkt" "big-crunch.rkt" "on-frame.rkt")
+(require rackunit pict3d racket/set "structures.rkt" "current-roll-and-pos.rkt" "variables.rkt" "big-crunch.rkt" "on-frame.rkt")
 (provide on-key on-release)
 
 (define (find-this-movekey key ms)
@@ -18,20 +18,26 @@
 (define (on-key g n ot key)
   (define t (- ot MASTER-TIME-OFFSET))
   (define lkey (string-foldcase key))
+  (define g*
+    (struct-copy game g
+                 [held-keys (set-add (game-held-keys g) lkey)]))
   (cond
     [(equal? key "escape")
-     (struct-copy game g
+     (struct-copy game g*
                   [exit? #t])]
     [(equal? key "\t")
-     (struct-copy game g
+     (struct-copy game g*
                   [scores? #t])]
-    [(find-this-movekey lkey (orb-movekeys (orbs-player (game-orbs g))))
+    [(set-member? (game-held-keys g) lkey)
+     ;; ignore it
      g]
+    [(find-this-movekey lkey (orb-movekeys (orbs-player (game-orbs g*))))
+     g*]
     [(member lkey '("w" "a" "s" "d" " " "shift" "q" "e"))
-     (struct-copy game g
-                  [orbs (on-orbs-key (game-orbs g) n t key)]
+     (struct-copy game g*
+                  [orbs (on-orbs-key (game-orbs g*) n t key)]
                   [mt t])]
-    [else g]))
+    [else g*]))
 
 (define (on-orbs-key os n t key)
   (struct-copy orbs os
@@ -59,15 +65,17 @@
 (define (on-release g n ot key)
   (define t (- ot MASTER-TIME-OFFSET))
   (define lkey (string-foldcase key))
+  (define g*
+    (struct-copy game g [held-keys (set-remove (game-held-keys g) lkey)]))
   (cond
     [(equal? key "\t")
-     (struct-copy game g
+     (struct-copy game g*
                   [scores? #f])]
     [(member lkey '("w" "a" "s" "d" " " "shift" "q" "e"))
-     (struct-copy game g
+     (struct-copy game g*
                   [orbs (on-orbs-release (game-orbs g) n t key)]
                   [mt t])]
-    [else g]))
+    [else g*]))
 
 (define (on-orbs-release os n t key)
     (struct-copy orbs os

--- a/client/key-events.rkt
+++ b/client/key-events.rkt
@@ -2,19 +2,6 @@
 (require rackunit pict3d racket/set "structures.rkt" "current-roll-and-pos.rkt" "variables.rkt" "big-crunch.rkt" "on-frame.rkt")
 (provide on-key on-release)
 
-(define (find-this-movekey key ms)
-  (cond
-    [(empty? ms)
-     #f]
-    [(equal? (movekey-key (first ms)) key)
-     (first ms)]
-    [else (find-this-movekey key (rest ms))]))
-
-(module+ test (check-equal? (find-this-movekey "w" '())
-                           #f))
-(module+ test (check-equal? (find-this-movekey "a" (list (movekey "w" 1/2) (movekey "a" 1/2)))
-                            (movekey "a" 1/2)))
-
 (define (on-key g n ot key)
   (define t (- ot MASTER-TIME-OFFSET))
   (define lkey (string-foldcase key))
@@ -31,8 +18,6 @@
     [(set-member? (game-held-keys g) lkey)
      ;; ignore it
      g]
-    [(find-this-movekey lkey (orb-movekeys (orbs-player (game-orbs g*))))
-     g*]
     [(member lkey '("w" "a" "s" "d" " " "shift" "q" "e"))
      (struct-copy game g*
                   [orbs (on-orbs-key (game-orbs g*) n t key)]

--- a/client/structures.rkt
+++ b/client/structures.rkt
@@ -17,7 +17,9 @@
 ;orbs is an orbs and exit? is wheather or not to stop the state and close the window
 ;;scores? is whether or not tab is pressed, to show scores ect.
 ;;mt is the time in milliseconds at last update and send of state
-(struct/lens game (mode orbs exit? scores? mt) #:transparent)
+;;held-keys is a set containing the keys that are currently pressed down, and
+;;  that we don't want to react to until they are released
+(struct/lens game (mode orbs exit? scores? mt held-keys) #:transparent)
 
 (define-nested-lenses [game-orbs game-orbs-lens]
   [enemys orbs-enemys-lens]

--- a/client/variables.rkt
+++ b/client/variables.rkt
@@ -19,7 +19,8 @@
    (orbs (orb DEFAULTPOS 0 '() DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0) empty)
    #f
    #f
-   0))
+   0
+   (set)))
 (define DEFAULT-ORB (orb DEFAULTPOS 0 '() DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0))
 
 (define ORB-RADIUS 2)


### PR DESCRIPTION
This change is not really necessary, but it would be necessary in an acceleration-based mode.

This separates the presence of a movekey from whether a movekey can be added, while keeping the behavior the same.
