### PR TITLE
refactor movekeys into a struct storing speeds

### DIFF
--- a/client/current-roll-and-pos.rkt
+++ b/client/current-roll-and-pos.rkt
@@ -13,38 +13,26 @@
 
 (module+ test (check-equal?
                (current-roll (struct-copy orb TESTORB
-                                         [movekeys (list (movekey "q" STARTING-SPEED))])
+                                         [movekeys (q-movekey STARTING-SPEED)])
                             6)
                (- (* ROTATION-SPEED-MULTIPLIER STARTING-SPEED))))
 (module+ test (check-equal?
                (current-roll (struct-copy orb TESTORB
-                                         [movekeys empty])
+                                         [movekeys empty-movekeys])
                             6)
                0))
 
 (define (adjust-ang ang ms dt)
-  (cond
-    [(empty? ms)
-     ang]
-    [else
-     (adjust-ang (adjust-one-ang-key ang (first ms) dt) (rest ms) dt)]))
+  (adjust-one-ang-key ang ms dt))
 
 (define (adjust-one-ang-key ang m dt)
-  (cond
-    [(equal? (movekey-key m) "q")
-     (- ang (* dt (movekey-speed m) ROTATION-SPEED-MULTIPLIER))]
-    [(equal? (movekey-key m) "e")
-     (+ ang (* dt (movekey-speed m) ROTATION-SPEED-MULTIPLIER))]
-    [else ang]))
+  (match m
+    [(movekeys w a space e)
+     (+ ang (* dt e ROTATION-SPEED-MULTIPLIER))]))
 
 ;;takes an orb and time and gives current position of the orb
 (define (current-pos o t)
-  (define ms (orb-movekeys o))
-  (cond
-    [(equal? ms '())
-     (orb-pos o)]
-    [else
-     (adjust-pos (orb-movekeys o) (orb-dir o) (orb-pos o) (- t (orb-time o)) t (current-roll o t))]))
+  (adjust-pos (orb-movekeys o) (orb-dir o) (orb-pos o) (- t (orb-time o)) t (current-roll o t)))
 
 (module+ test;;note: these tests rely on the fact that FINAL-LANDSCAPE is empty in the middle of the room.
   (check-equal?
@@ -52,84 +40,72 @@
    (pos 1 1 1))
   (check-equal?
    (current-pos (struct-copy orb TESTORB
-                             [movekeys (list (movekey "w" 1/2))]
+                             [movekeys (w-movekey 1/2)]
                              [pos (pos 25 21 21)]
                              [time 5]) 7)
    (pos 24 21 21))
   (check-equal?
    (current-pos (struct-copy orb TESTORB
-                             [movekeys (list (movekey "s" 1/2))]
+                             [movekeys (s-movekey 1/2)]
                              [pos (pos 25 21 21)]
                              [time 5]) 7)
    (pos 26 21 21))
   (check-equal?
    (round-pos
     (current-pos (struct-copy orb TESTORB
-                              [movekeys (list (movekey "a" 1/2))]
+                              [movekeys (a-movekey 1/2)]
                               [pos (pos 21 21 21)]
                               [time 5]) 7))
    (pos 21 20 21))
   (check-equal?
    (round-pos
     (current-pos (struct-copy orb TESTORB
-                              [movekeys (list (movekey "d" 1/2))]
+                              [movekeys (d-movekey 1/2)]
                               [pos (pos 21 21 21)]
                               [time 5]) 7))
    (pos 21 22 21))
   (check-equal?
    (round-pos
     (current-pos (struct-copy orb TESTORB
-                              [movekeys (list (movekey " " 1/2))]
+                              [movekeys (space-movekey 1/2)]
                               [pos (pos 21 21 21)]
                               [time 5]) 7))
    (pos 21 21 22))
   (check-equal?
    (round-pos
     (current-pos (struct-copy orb TESTORB
-                              [movekeys (list (movekey "shift" 1/2))]
+                              [movekeys (shift-movekey 1/2)]
                               [pos (pos 21 21 21)]
                               [time 5]) 7))
    (pos 21 21 20)))
 
 ;;pos, list of movekeys, a dir, deltatime, and time-> ajusted position of the orb for the axis
 (define (adjust-pos ms d p dt t ang)
-  (cond
-    [(empty? ms)
-     p]
-    [else
-     (adjust-pos (rest ms) d (adjust-one-key (first ms) d p dt ang) dt t ang)]))
+  (adjust-one-key ms d p dt ang))
 
-;; key, speed, dir, and angle -> velocity
+;; movekeys, dir, and angle -> velocity
 ;; pd is d adjusted by 90 degrees for pitch, and yd is adjusted 90 degrees for
 ;; yaw, and then they are adjusted for the angle the camera is turned
-(define (key-velocity k s d ang)
+(define (key-velocity mk d ang)
   (define-values (yaw pitch) (dir->angles d))
   (define pd (rotate-around-dir (rotate-up d) d ang))
   (define yd (angles->dir (+ 90 yaw) ang))
-  (cond
-    [(equal? k "w")
-     (dir-scale d s)]
-    [(equal? k "s")
-     (dir-scale (dir-negate d) s)]
-    [(equal? k "a")
-     (dir-scale yd s)]
-    [(equal? k "d")
-     (dir-scale (dir-negate yd) s)]
-    [(equal? k "shift")
-     (dir-scale (dir-negate pd) s)]
-    [(equal? k " ")
-     (dir-scale pd s)]
-    [else
-     (error 'key-velocity "unrecognized key: ~v" k)]))
+  (match mk
+    [(movekeys w a space e)
+     (foldl dir+ zero-dir
+            (list
+             (dir-scale d w)
+             (dir-scale yd a)
+             (dir-scale pd space)))]))
 
 ;;movekey, dir, pos, delta-time, angle -> pos
 (define (adjust-one-key mk d p dt ang)
-  (cond
-    [(member (movekey-key mk) '("w" "a" "s" "d" "shift" " "))
+  (match mk
+    [(movekeys 0 0 0 0)
+     p]
+    [_
      (move-with-collision*
       p
-      (key-velocity (movekey-key mk) (movekey-speed mk) d ang)
+      (key-velocity mk d ang)
       dt
-      FINAL-LANDSCAPE)]
-    [else
-     p]))
+      FINAL-LANDSCAPE)]))

--- a/client/key-events.rkt
+++ b/client/key-events.rkt
@@ -39,11 +39,22 @@
   (struct-copy orb o
                [pos (current-pos o t)]
                [time t]
-               [movekeys (cons (movekey lkey STARTING-SPEED)  (orb-movekeys o))]
+               [movekeys (movekeys-add-key (orb-movekeys o) lkey STARTING-SPEED)]
                [roll (current-roll o t)]))
 
-(module+ test (check-equal? (on-player-key (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys empty]) "n" 5 "shift")
-              (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys (list (movekey "shift" STARTING-SPEED))])))
+(define (movekeys-add-key mks lkey speed)
+  (match lkey
+    ["w" (movekeys+w mks speed)]
+    ["a" (movekeys+a mks speed)]
+    ["s" (movekeys+s mks speed)]
+    ["d" (movekeys+d mks speed)]
+    [" " (movekeys+space mks speed)]
+    ["shift" (movekeys+shift mks speed)]
+    ["q" (movekeys+q mks speed)]
+    ["e" (movekeys+e mks speed)]))
+
+(module+ test (check-equal? (on-player-key (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys empty-movekeys]) "n" 5 "shift")
+              (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys (shift-movekey STARTING-SPEED)])))
 
 ;#############################################################################################################################################################################################
 
@@ -78,16 +89,9 @@
                o
                [pos (current-pos o t)]
                [time t]
-               [movekeys (remove-this-movekey (orb-movekeys o) lkey)]
+               [movekeys (movekeys-add-key (orb-movekeys o) lkey (- STARTING-SPEED))]
                [roll (current-roll o t)]))
 
-(module+ test (check-equal? (on-player-release (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys (list (movekey " " 1))]) "n" 5 " ")
-              (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys empty])))
+(module+ test (check-equal? (on-player-release (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys (space-movekey STARTING-SPEED)]) "n" 5 " ")
+              (struct-copy orb TESTORB [pos (pos 2 2 2)] [movekeys empty-movekeys])))
 
-(define (remove-this-movekey ms key)
-  (cond
-    [(empty? ms) ms]
-    [(equal? key (movekey-key (first ms)))
-     (remove-this-movekey (rest ms) key)]
-    [else
-     (cons (first ms) (remove-this-movekey (rest ms) key))]))

--- a/client/on-frame.rkt
+++ b/client/on-frame.rkt
@@ -262,7 +262,7 @@
                    DEFAULTPOS2]
                   [else
                    DEFAULTPOS])]
-               [movekeys empty]
+               [movekeys empty-movekeys]
                [dir DEFAULTDIR2]
                [roll 0]))
 

--- a/client/structures.rkt
+++ b/client/structures.rkt
@@ -2,8 +2,10 @@
 (require pict3d lens unstable/lens)
 (provide (all-defined-out))
 
-;; key and the speed it is moving in that direction
-(struct/lens movekey (key speed) #:prefab)
+;; speeds in the given key directions
+;; the keys s, d, shift, and q are represented by negetive numbers
+;;   in the w, a, space, and e fields.
+(struct/lens movekeys (w a space e) #:prefab)
 ;corner 1 and 2 are pos for drawing and pos is where to move it
 ;time is time in milliseconds when it was shot
 (struct/lens shot (corner1 corner2 pos yaw pitch time) #:prefab)
@@ -37,6 +39,45 @@
 (struct/lens mypos (x y z) #:prefab)
 (struct/lens mydir (dx dy dz) #:prefab)
 (struct/lens mycube (pos scale color) #:prefab)
+
+(define empty-movekeys
+  (movekeys 0 0 0 0))
+
+(define (movekeys+w mks w2)
+  (lens-transform movekeys-w-lens mks (λ (w) (+ w w2))))
+(define (movekeys+a mks a2)
+  (lens-transform movekeys-a-lens mks (λ (a) (+ a a2))))
+(define (movekeys+space mks space2)
+  (lens-transform movekeys-space-lens mks (λ (space) (+ space space2))))
+(define (movekeys+e mks e2)
+  (lens-transform movekeys-e-lens mks (λ (e) (+ e e2))))
+
+(define (movekeys+s mks s)
+  (movekeys+w mks (- s)))
+(define (movekeys+d mks d)
+  (movekeys+a mks (- d)))
+(define (movekeys+shift mks shift)
+  (movekeys+space mks (- shift)))
+(define (movekeys+q mks q)
+  (movekeys+e mks (- q)))
+
+(define (w-movekey w)
+  (movekeys w 0 0 0))
+(define (a-movekey a)
+  (movekeys 0 a 0 0))
+(define (space-movekey space)
+  (movekeys 0 0 space 0))
+(define (e-movekey e)
+  (movekeys 0 0 0 e))
+
+(define (s-movekey s)
+  (w-movekey (- s)))
+(define (d-movekey d)
+  (a-movekey (- d)))
+(define (shift-movekey shift)
+  (space-movekey (- shift)))
+(define (q-movekey q)
+  (e-movekey (- q)))
 
 (define/match (pos->mypos p)
   [[(pos x y z)]

--- a/client/variables.rkt
+++ b/client/variables.rkt
@@ -16,12 +16,12 @@
 (define DEFAULT-STATE
   (game
    'deathmatch
-   (orbs (orb DEFAULTPOS 0 '() DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0) empty)
+   (orbs (orb DEFAULTPOS 0 empty-movekeys DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0) empty)
    #f
    #f
    0
    (set)))
-(define DEFAULT-ORB (orb DEFAULTPOS 0 '() DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0))
+(define DEFAULT-ORB (orb DEFAULTPOS 0 empty-movekeys DEFAULTDIR 0 empty 0 "1" "blue" #f #f 0 0))
 
 (define ORB-RADIUS 2)
 
@@ -35,7 +35,7 @@
 (define SERVER-ADRESS "10.0.1.12")
 (define CLIENT-ADRESS "c-67-166-78-233.hsd1.ut.comcast.net")
 
-(define TESTORB (orb (pos 1 1 1) 5 '() (dir -1 0 0) 0 empty 0 "Bob" "blue" #f #f 0 0))
+(define TESTORB (orb (pos 1 1 1) 5 empty-movekeys (dir -1 0 0) 0 empty 0 "Bob" "blue" #f #f 0 0))
 
 (define DISCO? #f)
 


### PR DESCRIPTION
movekeys is now a struct with the fields w, a, space, and e, storing the speeds in each of those directions. 

This eliminates the need for searching through lists to find move keys and going through multiple keys each time an orb is moved.
