### PR TITLE
fix another "artificial gravity" bug

### DIFF
--- a/client/on-frame.rkt
+++ b/client/on-frame.rkt
@@ -254,7 +254,7 @@
                    DEFAULTPOS2]
                   [else
                    DEFAULTPOS])]
-               [movekeys empty-movekeys]
+               ;[movekeys empty-movekeys]
                [dir DEFAULTDIR2]
                [roll 0]))
 


### PR DESCRIPTION
before this, if you respawned while pressing a key, you would start out
stationary when you respawned, but when you released the key, it would
start moving in the opposite direction
